### PR TITLE
Fix license metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "planetoftheweb/flex-videos",
     "description": "A professional WordPress plugin for displaying flexible, responsive video embeds with YouTube API integration",
     "type": "wordpress-plugin",
-    "license": "MIT",
+    "license": "GPL-2.0-or-later",
     "version": "1.0.1",
     "authors": [
         {


### PR DESCRIPTION
## Summary
- switch plugin license to GPL-2.0-or-later in `composer.json`
- keep docs pointing to the same GPL license

## Testing
- `composer run test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686299b3da74832bb97a749a1e3d1606