### PR TITLE
Fix CI plugin lint path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
       - name: Validate plugin PHP
-        run: php -l flex_videos-plugin.php
+        run: php -l flex-videos.php
       - name: Check README exists
         run: test -f README.md


### PR DESCRIPTION
## Summary
- correct the PHP lint path in CI workflow
- install Composer dependencies in CI

## Testing
- `composer run test` *(fails: requires tests)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68629de8405c832b91e9d8d191afbfea