### PR TITLE
Update uninstall script options and cache cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -11,14 +11,50 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 }
 
 // Delete plugin options
-delete_option('itsplaitime_yt_api_key');
-delete_option('itsplaitime_yt_channel_id');
+$option_keys = [
+    'flex_videos_api_key',
+    'flex_videos_channel_id',
+    'flex_videos_columns',
+    'flex_videos_gap',
+    'flex_videos_show_grid_title',
+    'flex_videos_show_grid_description',
+    'flex_videos_num_videos',
+    'flex_videos_custom_grid_title',
+    'flex_videos_custom_grid_desc',
+    'flex_videos_show_channel_link',
+    'flex_videos_channel_link_text',
+    'flex_videos_button_color',
+    'flex_videos_button_hover_color',
+    'flex_videos_button_text_color',
+    'flex_videos_cache_version',
+    'flex_videos_db_version',
+    'flex_videos_activated',
+];
 
-// Delete any cached data
+foreach ($option_keys as $key) {
+    delete_option($key);
+}
+
+// Delete cached transients
+global $wpdb;
+$patterns = [
+    '_transient_flex_videos_channel_info_%',
+    '_transient_timeout_flex_videos_channel_info_%',
+    '_transient_flex_videos_search_cache_%',
+    '_transient_timeout_flex_videos_search_cache_%',
+];
+foreach ($patterns as $pattern) {
+    $wpdb->query(
+        $wpdb->prepare(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+            $pattern
+        )
+    );
+}
+
+// Clear object cache if used
 wp_cache_delete('flex_videos_cache', 'flex_videos');
-
-// Clean up any custom database tables if you had any
-// (Your current plugin doesn't seem to create custom tables, but this is where you'd clean them up)
 
 // Clear any scheduled cron jobs related to this plugin
 wp_clear_scheduled_hook('flex_videos_cache_cleanup');
+


### PR DESCRIPTION
## Summary
- update uninstall script to remove new `flex_videos_*` options
- clear flex video transients when uninstalling

## Testing
- `composer test` *(fails: command not found)*
- `npm test` *(fails: missing script and network access)*
- `phpcs -i` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686299be305c832bae8bc3d5d6ec9dde