### PR TITLE
Add Gutenberg block

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ cd /wp-content/plugins/
 git clone https://github.com/planetoftheweb/flex-videos.git
 ```
 
+### Building the Block
+
+This plugin uses `@wordpress/scripts` for compiling the Gutenberg block code.
+Run the following commands from the plugin directory:
+
+```bash
+npm install
+npm run build
+```
+
+During development you can use `npm start` to watch for changes.
+
 ## Configuration
 
 Go to **Settings > Flex Videos** in WordPress admin:
@@ -83,6 +95,8 @@ Go to **Settings > Flex Videos** in WordPress admin:
 - **Reset Plugin Settings** - Restore all settings to defaults
 
 ## Usage
+
+You can insert the **Flex Videos Grid** block from the block editor or use the shortcode as documented below.
 
 ### Video Grid Shortcode
 

--- a/blocks/flex-videos-grid/block.json
+++ b/blocks/flex-videos-grid/block.json
@@ -1,0 +1,9 @@
+{
+    "apiVersion": 2,
+    "name": "flex-videos/grid",
+    "title": "Flex Videos Grid",
+    "category": "widgets",
+    "icon": "video-alt3",
+    "description": "Display a responsive YouTube grid using the Flex Videos shortcode.",
+    "editorScript": "file:./index.js"
+}

--- a/blocks/flex-videos-grid/index.js
+++ b/blocks/flex-videos-grid/index.js
@@ -1,0 +1,11 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+registerBlockType( 'flex-videos/grid', {
+    edit() {
+        return __( 'Flex Videos Grid', 'flex-videos' );
+    },
+    save() {
+        return null;
+    }
+} );

--- a/blocks/flex-videos-grid/index.php
+++ b/blocks/flex-videos-grid/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/blocks/index.php
+++ b/blocks/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/blocks/register-block.php
+++ b/blocks/register-block.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Registers the Flex Videos block.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function flex_videos_register_block() {
+    register_block_type( __DIR__ . '/flex-videos-grid', [
+        'render_callback' => 'flex_videos_render_block',
+    ] );
+}
+add_action( 'init', 'flex_videos_register_block' );
+
+function flex_videos_render_block( $attributes, $content ) {
+    return do_shortcode( '[flex_videos]' );
+}

--- a/flex-videos.php
+++ b/flex-videos.php
@@ -19,6 +19,9 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Register Gutenberg block.
+require_once plugin_dir_path( __FILE__ ) . 'blocks/register-block.php';
+
 // --- PLUGIN SETTINGS & CACHE HANDLING ---
 
 function flex_videos_add_admin_menu() {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
     "responsive",
     "embed",
     "api"
-  ]
+  ],
+  "scripts": {
+    "build": "wp-scripts build",
+    "start": "wp-scripts start"
+  },
+  "devDependencies": {
+    "@wordpress/scripts": "^30.19.0"
+  }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ Initial release of Flex Videos plugin.
 
 == Usage ==
 
-Use the shortcode `[flex_videos]` to display a grid of videos from your configured YouTube channel.
+You can add the **Flex Videos Grid** block in the editor or use the shortcode `[flex_videos]` to display a grid of videos from your configured YouTube channel.
 
 Available shortcode attributes:
 * `columns` - Number of columns (1-10, default: 3)


### PR DESCRIPTION
## Summary
- register a Flex Videos block
- bundle block scripts with `@wordpress/scripts`
- document building the block and block usage

## Testing
- `composer phpcs` *(fails: command not found)*
- `npm install` *(fails: ETARGET for `@wordpress/scripts`)*

------
https://chatgpt.com/codex/tasks/task_e_6862e64dbff8832baaadbc8182c7cb75