### PR TITLE
Integrate GitHub update checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ npm run build
 
 During development you can use `npm start` to watch for changes.
 
+### Releasing Updates
+
+When you are ready to publish a new version, create a Git tag matching the
+version number and push it to GitHub. WordPress sites running this plugin will
+detect the tagged release and offer the update automatically.
+
 ## Configuration
 
 Go to **Settings > Flex Videos** in WordPress admin:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "source": "https://github.com/planetoftheweb/flex-videos"
     },
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "yahnis-elsts/plugin-update-checker": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/flex-videos.php
+++ b/flex-videos.php
@@ -10,13 +10,28 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       flex-videos
  * Requires at least: 5.0
- * Tested up to:      6.5
+ * Tested up to:      6.8
  * Requires PHP:      7.4
+ * Update URI:        https://github.com/planetoftheweb/flex-videos/
  */
 
 // Block direct access to the file.
 if (!defined('ABSPATH')) {
     exit;
+}
+
+// Load Composer dependencies if available.
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Plugin update checker.
+if (class_exists('\\Puc_v4_Factory')) {
+    Puc_v4_Factory::buildUpdateChecker(
+        'https://github.com/planetoftheweb/flex-videos/',
+        __FILE__,
+        'flex-videos'
+    );
 }
 
 // Register Gutenberg block.


### PR DESCRIPTION
## Summary
- register plugin update checker
- load composer autoload for dependency
- document release tagging for automatic updates
- add plugin-update-checker requirement
- align tested versions between plugin header and readme

## Testing
- `composer validate --no-check-all`
- `composer test` *(fails: dom, xml, xmlwriter extensions missing)*
- `composer phpcs` *(fails: tokenizer, xmlwriter and SimpleXML extensions missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862ec3a2cb8832bbfaae8921be66783