### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.2] - 2025-07-01
+
+### Added
+- Gutenberg block for inserting video grids
+- GitHub update checker for automatic plugin updates
+- AJAX-powered cache reset button in plugin settings
+
+### Changed
+- Refactored uninstall process to better clean transients and options
+- Minified CSS/JS and optimized selectors
 
 ### Removed
 - Obsolete `includes/class-flex-videos.php` and Composer autoload configuration.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A WordPress plugin for displaying responsive YouTube video grids with modern fly
 - **Built-in Caching** - API responses are cached for optimal performance
 - **Optimized Thumbnails** - Medium resolution for grid performance, high-resolution for overlay quality
 - **WordPress Compatible** - Follows WordPress coding standards and best practices
+- **Gutenberg Block** - Insert video grids directly from the block editor
+- **Automatic Updates** - Built-in GitHub update checker for easy upgrades
 
 ## What Makes It Special
 
@@ -67,7 +69,7 @@ During development you can use `npm start` to watch for changes.
 
 When you are ready to publish a new version, create a Git tag matching the
 version number and push it to GitHub. WordPress sites running this plugin will
-detect the tagged release and offer the update automatically.
+detect the tagged release and offer the update automatically thanks to the built-in GitHub update checker.
 
 ## Configuration
 
@@ -98,6 +100,7 @@ Go to **Settings > Flex Videos** in WordPress admin:
 ### Admin Tools
 - **Test API Key** - Verify your YouTube API connection
 - **Clear Cache** - Remove cached API responses
+- **One-click Cache Reset** - Instant AJAX cache clearing from settings
 - **Reset Plugin Settings** - Restore all settings to defaults
 
 ## Usage

--- a/assets/css/flex-videos.css
+++ b/assets/css/flex-videos.css
@@ -2,7 +2,7 @@
  * Flex Videos Plugin Styles
  * 
  * @package FlexVideos
- * @version 1.0.1
+ * @version 1.0.2
  */
 
 /* CSS Custom Properties for Theme Customization */

--- a/assets/js/flex-videos.js
+++ b/assets/js/flex-videos.js
@@ -2,7 +2,7 @@
  * Flex Videos Plugin JavaScript
  * 
  * @package FlexVideos
- * @version 1.0.1
+ * @version 1.0.2
  */
 
 (function($) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A professional WordPress plugin for displaying flexible, responsive video embeds with YouTube API integration",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "authors": [
         {
             "name": "Ray Villalobos",

--- a/flex-videos.php
+++ b/flex-videos.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Flex Videos
  * Plugin URI:        https://github.com/planetoftheweb/flex-videos
  * Description:       A WordPress plugin for displaying flexible, responsive video embeds with YouTube API integration.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            Ray Villalobos
  * Author URI:        https://itsplaitime.com/
  * License:           GPL-2.0-or-later
@@ -635,8 +635,8 @@ add_action('admin_init', 'flex_videos_test_api_key');
 
 // Enqueue Flex Videos CSS and JS
 function flex_videos_enqueue_assets() {
-    wp_enqueue_style('flex-videos-css', plugins_url('assets/css/flex-videos.min.css', __FILE__), [], '1.0.1');
-    wp_enqueue_script('flex-videos-flyout', plugins_url('assets/js/flex-videos-flyout.min.js', __FILE__), [], '1.0.1', true);
+    wp_enqueue_style('flex-videos-css', plugins_url('assets/css/flex-videos.min.css', __FILE__), [], '1.0.2');
+    wp_enqueue_script('flex-videos-flyout', plugins_url('assets/js/flex-videos-flyout.min.js', __FILE__), [], '1.0.2', true);
     
     // Add custom button colors
     $button_color = get_option('flex_videos_button_color', '#ff8c00');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flex-videos",
   "description": "A WordPress plugin for displaying flexible, responsive video embeds with YouTube API integration",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "GPL-2.0-or-later",
   "author": "Ray Villalobos",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rayvillalobos
 Tags: youtube, video, grid, responsive, embed
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -71,6 +71,12 @@ Yes, you can use the hashtag attribute in the shortcode to filter videos contain
 
 == Changelog ==
 
+= 1.0.2 =
+* Added Gutenberg block for inserting video grids
+* Introduced GitHub update checker for automatic updates
+* Added AJAX-powered cache reset button in settings
+* Refactored uninstall process for better cleanup
+
 = 1.0.1 =
 * Fixed WordPress plugin checker compliance issues
 * Added proper sanitization to all settings fields
@@ -89,6 +95,9 @@ Yes, you can use the hashtag attribute in the shortcode to filter videos contain
 * WordPress coding standards compliance
 
 == Upgrade Notice ==
+
+= 1.0.2 =
+Recommended update adding Gutenberg block, GitHub updater and improved cache management.
 
 = 1.0.1 =
 Important security and compliance update. Fixes WordPress plugin checker issues and improves overall plugin security.


### PR DESCRIPTION
## Summary
- bump plugin version to 1.0.2
- document new features in CHANGELOG and readme files
- mention Gutenberg block and GitHub updater in README
- update asset version comments and enqueue versions

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686324f2488c832b9a4d4753d9b2d259