### PR TITLE
Remove Vimeo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Embed individual videos with inline playback:
 [flex_video url="https://www.youtube.com/watch?v=VIDEO_ID"]
 ```
 
-Supports both YouTube and Vimeo URLs. Automatically fetches title and description from the video API.
+Automatically fetches title and description for YouTube videos using the API.
 
 ## Visual Behavior
 

--- a/flex-videos.php
+++ b/flex-videos.php
@@ -567,13 +567,6 @@ function flex_video_single_shortcode($atts) {
         } else {
             return __('Invalid YouTube URL.', 'flex-videos');
         }
-    } elseif (strpos($url, 'vimeo.com') !== false) {
-        if (preg_match('/vimeo.com\/(\d+)/', $url, $matches)) {
-            $video_id = $matches[1];
-            $embed_url = 'https://player.vimeo.com/video/' . esc_attr($video_id);
-        } else {
-            return __('Invalid Vimeo URL.', 'flex-videos');
-        }
     } else {
         return __('Unsupported video URL.', 'flex-videos');
     }

--- a/languages/flex-videos.pot
+++ b/languages/flex-videos.pot
@@ -257,9 +257,6 @@ msgstr ""
 msgid "Invalid YouTube URL."
 msgstr ""
 
-#: flex-videos.php:543
-msgid "Invalid Vimeo URL."
-msgstr ""
 
 #: flex-videos.php:546
 msgid "Unsupported video URL."


### PR DESCRIPTION
## Summary
- remove mention of Vimeo from the single video instructions in README
- drop Vimeo embed support from shortcode implementation
- delete the translation string for the old Vimeo error message

## Testing
- `composer test` *(fails: composer not found)*
- `phpunit --version` *(fails: command not found)*
- `phpcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632862fd74832b991f52a1688e938b